### PR TITLE
fix: make all peer deps work for higher versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch/hooks",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "scripts": {
     "build": "rm -rf ./dist && export BABEL_ENV=production && babel src --out-dir dist --ignore 'src/**/*.test.js'",
     "build:test": "rm -rf ./dist && export BABEL_ENV=production && babel src --out-dir dist",
@@ -36,7 +36,7 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   }
 }


### PR DESCRIPTION
Make react and react-dom peer dependencies compatible with all higher versions. Upgrade version number to reflect this patch.